### PR TITLE
Rename Boolean fields to provide standard isXXX getter

### DIFF
--- a/mixite.core/core/src/main/kotlin/org/hexworks/mixite/core/api/contract/SatelliteData.kt
+++ b/mixite.core/core/src/main/kotlin/org/hexworks/mixite/core/api/contract/SatelliteData.kt
@@ -17,7 +17,7 @@ interface SatelliteData {
      *
      * @param passable passable?
      */
-    var passable: Boolean
+    var isPassable: Boolean
 
     /**
      * @return true if the [Hexagon] can bee seen through, false otherwise.
@@ -27,7 +27,7 @@ interface SatelliteData {
      *
      * @param opaque is opaque?
      */
-    var opaque: Boolean
+    var isOpaque: Boolean
 
     /**
      * Returns the movement cost when moving over the Hexagon.

--- a/mixite.core/core/src/main/kotlin/org/hexworks/mixite/core/api/defaults/DefaultSatelliteData.kt
+++ b/mixite.core/core/src/main/kotlin/org/hexworks/mixite/core/api/defaults/DefaultSatelliteData.kt
@@ -6,6 +6,6 @@ import org.hexworks.mixite.core.api.contract.SatelliteData
  * Convenience class implementing SatelliteData.
  */
 open class DefaultSatelliteData(
-        override var passable: Boolean = false,
-        override var opaque: Boolean = false,
+        override var isPassable: Boolean = false,
+        override var isOpaque: Boolean = false,
         override var movementCost: Double = 0.toDouble()) : SatelliteData

--- a/mixite.core/core/src/main/kotlin/org/hexworks/mixite/core/internal/impl/HexagonalGridCalculatorImpl.kt
+++ b/mixite.core/core/src/main/kotlin/org/hexworks/mixite/core/internal/impl/HexagonalGridCalculatorImpl.kt
@@ -80,7 +80,7 @@ class HexagonalGridCalculatorImpl<T : SatelliteData>(private val hexagonalGrid: 
             if (pathHexagon.equals(from) || pathHexagon.equals(to)) {
                 continue
             }
-            if (pathHexagon.satelliteData.isPresent && pathHexagon.satelliteData.get().opaque) {
+            if (pathHexagon.satelliteData.isPresent && pathHexagon.satelliteData.get().isOpaque) {
                 return false
             }
         }

--- a/mixite.core/core/src/test/kotlin/org/hexworks/mixite/core/api/DefaultSatelliteDataTest.kt
+++ b/mixite.core/core/src/test/kotlin/org/hexworks/mixite/core/api/DefaultSatelliteDataTest.kt
@@ -19,14 +19,14 @@ class DefaultSatelliteDataTest {
 
     @Test
     fun shouldProperlySetAndGetIsPassable() {
-        target.passable = EXPECTED_IS_PASSABLE
-        assertEquals(EXPECTED_IS_PASSABLE, target.passable)
+        target.isPassable = EXPECTED_IS_PASSABLE
+        assertEquals(EXPECTED_IS_PASSABLE, target.isPassable)
     }
 
     @Test
     fun shouldProperlySetAndGetIsBlocksView() {
-        target.opaque = EXPECTED_IS_BLOCKS_VIEW
-        assertEquals(EXPECTED_IS_BLOCKS_VIEW, target.opaque)
+        target.isOpaque = EXPECTED_IS_BLOCKS_VIEW
+        assertEquals(EXPECTED_IS_BLOCKS_VIEW, target.isOpaque)
     }
 
     @Test

--- a/mixite.core/core/src/test/kotlin/org/hexworks/mixite/core/internal/impl/HexagonalGridCalculatorImplTest.kt
+++ b/mixite.core/core/src/test/kotlin/org/hexworks/mixite/core/internal/impl/HexagonalGridCalculatorImplTest.kt
@@ -105,7 +105,7 @@ class HexagonalGridCalculatorImplTest {
 
         val hexagon = grid.getByCubeCoordinate(fromCoordinates(2, 5))
         val data = DefaultSatelliteData()
-        data.opaque = true
+        data.isOpaque = true
         hexagon.get().setSatelliteData(data)
 
         assertFalse {


### PR DESCRIPTION
Rename resolving #42. I have a bunch of changes I would like to make (*) so am testing to see if PRs are accepted : )

(*) I actually did many refactorings years ago against hexameter but didn't share.