### PR TITLE
Added cubeToOffset converters and tests

### DIFF
--- a/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/api/CoordinateConverter.kt
+++ b/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/api/CoordinateConverter.kt
@@ -40,6 +40,40 @@ class CoordinateConverter {
         fun convertOffsetCoordinatesToCubeZ(offsetX: Int, offsetY: Int, orientation: HexagonOrientation): Int {
             return if (HexagonOrientation.FLAT_TOP.equals(orientation)) offsetY - offsetX / 2 else offsetY
         }
+
+        /**
+         * Calculates the offset row based on a CubeCoordinate.
+         *
+         * @Param cubeCoordinate a cube coordinate
+         * @param orientation orientation
+         *
+         * @return offset row or y-value
+         */
+        @JvmStatic
+        fun convertCubeCoordinateToOffsetRow(coordinate: CubeCoordinate, orientation: HexagonOrientation): Int {
+            return if(HexagonOrientation.FLAT_TOP.equals(orientation)) {
+                coordinate.gridZ + (coordinate.gridX - (coordinate.gridX and 1)) / 2
+            } else {
+                coordinate.gridZ
+            }
+        }
+
+        /**
+         * Calculates the offset column based on a CubeCoordinate.
+         *
+         * @Param cubeCoordinate a cube coordinate
+         * @param orientation orientation
+         *
+         * @return offset column or x-value
+         */
+        @JvmStatic
+        fun convertCubeCoordinateToOffsetColumn(coordinate: CubeCoordinate, orientation: HexagonOrientation): Int {
+            return if(HexagonOrientation.FLAT_TOP.equals(orientation)) {
+                coordinate.gridX
+            } else {
+                coordinate.gridX + (coordinate.gridZ - (coordinate.gridZ and 1)) / 2
+            }
+        }
     }
 
 }

--- a/mixite.core/src/commonTest/kotlin/org/hexworks/mixite/core/api/CoordinateConverterTest.kt
+++ b/mixite.core/src/commonTest/kotlin/org/hexworks/mixite/core/api/CoordinateConverterTest.kt
@@ -40,6 +40,38 @@ class CoordinateConverterTest {
     }
 
     @Test
+    fun shouldConvertCubeCoordinatesToOffsetRowWithFlat() {
+        for((i, cube) in testCubes.withIndex()) {
+            val result = CoordinateConverter.convertCubeCoordinateToOffsetRow(cube, HexagonOrientation.FLAT_TOP)
+            assertEquals(expectedOffsetRowWithFlat[i], result, "(" + cube.gridX + "," + cube.gridZ + ") to " + result)
+        }
+    }
+
+    @Test
+    fun shouldConvertCubeCoordinatesToOffsetColWithFlat() {
+        for((i, cube) in testCubes.withIndex()) {
+            val result = CoordinateConverter.convertCubeCoordinateToOffsetColumn(cube, HexagonOrientation.FLAT_TOP)
+            assertEquals(expectedOffsetColWithFlat[i], result, "(" + cube.gridX + "," + cube.gridZ + ") to " + result)
+        }
+    }
+
+    @Test
+    fun shouldConvertCubeCoordinatesToOffsetRowWithPointy() {
+        for((i, cube) in testCubes.withIndex()) {
+            val result = CoordinateConverter.convertCubeCoordinateToOffsetRow(cube, HexagonOrientation.POINTY_TOP)
+            assertEquals(expectedOffsetRowWithPointy[i], result, "(" + cube.gridX + "," + cube.gridZ + ") to " + result)
+        }
+    }
+
+    @Test
+    fun shouldConvertCubeCoordinatesToOffsetColWithPointy() {
+        for((i, cube) in testCubes.withIndex()) {
+            val result = CoordinateConverter.convertCubeCoordinateToOffsetColumn(cube, HexagonOrientation.POINTY_TOP)
+            assertEquals(expectedOffsetColWithPointy[i], result, "(" + cube.gridX + "," + cube.gridZ + ") to " + result)
+        }
+    }
+
+    @Test
     fun shouldCreateKeyFromCoordinate() {
         assertEquals(TEST_KEY, fromCoordinates(TEST_GRID_X, TEST_GRID_Z).toAxialKey())
     }
@@ -63,5 +95,16 @@ class CoordinateConverterTest {
         private const val EXPECTED_AXIAL_X_WITH_FLAT = 3
         private const val EXPECTED_AXIAL_Z_WITH_POINTY = 4
         private const val EXPECTED_AXIAL_Z_WITH_FLAT = 3
+
+        private val testCubes = arrayOf(
+            CubeCoordinate.fromCoordinates(-1, -2),
+            CubeCoordinate.fromCoordinates( 2, -3),
+            CubeCoordinate.fromCoordinates( 7,  8)
+        )
+
+        private val expectedOffsetColWithFlat   = intArrayOf(-1, 2, 7)
+        private val expectedOffsetRowWithFlat   = intArrayOf(-3,-2,11)
+        private val expectedOffsetColWithPointy = intArrayOf(-2, 0,11)
+        private val expectedOffsetRowWithPointy = intArrayOf(-2,-3, 8)
     }
 }


### PR DESCRIPTION
* Please let me know if there are any formatting corrections I should know about.
* I used the column-row naming convention from Amit's guide but conflicting with the offsetX-offsetY convention in the offsetToCube converters. I thought column and row was more intuitive. Should I change this?
* I used three separate coordinates in the test functions. I thought it would be best to test positive, negative, odd and even values. I'm not sure if using an array as I did is the best approach. Another alternative would be to just add more test methods for each value, but that would blow up a lot boilerplate code. Or I could just test a single value like the other test functions.
* The OffsetToCube converters use a simplifying assumption that the offset coordinates can never be negative. I don't believe I can do the same thing for CubeToOffset since some cube coordinates will be negative in a rectangular grid.