### PR TITLE
Rewrite calculateRingFrom and related changes

### DIFF
--- a/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/api/HexagonalGrid.kt
+++ b/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/api/HexagonalGrid.kt
@@ -90,6 +90,13 @@ interface HexagonalGrid<T : SatelliteData> {
     fun getByPixelCoordinate(coordinateX: Double, coordinateY: Double): Maybe<Hexagon<T>>
 
     /**
+     * Returns the coordinate of a neighbor of a Hexagon by its neighbor index.
+     *
+     * @return CubeCoordinate
+     */
+    fun getNeighborCoordinateByIndex(coordinate: CubeCoordinate, index: Int): CubeCoordinate
+
+    /**
      * Returns a neighbor of a Hexagon by its neighbor index.
      *
      * @return neighbor or empty Maybe if not applicable

--- a/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/api/HexagonalGridCalculator.kt
+++ b/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/api/HexagonalGridCalculator.kt
@@ -20,6 +20,11 @@ import org.hexworks.mixite.core.api.contract.SatelliteData
 interface HexagonalGridCalculator<T : SatelliteData> {
 
     /**
+     * The hexagonal grid used for the calculations
+     */
+    val hexagonalGrid: HexagonalGrid<T>
+
+    /**
      * Calculates the distance (in hexagons) between two [Hexagon] objects on the grid.
      *
      * @param hex0 hex 0

--- a/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/internal/impl/HexagonalGridCalculatorImpl.kt
+++ b/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/internal/impl/HexagonalGridCalculatorImpl.kt
@@ -8,7 +8,7 @@ import kotlin.math.max
 import kotlin.math.min
 import kotlin.math.round
 
-class HexagonalGridCalculatorImpl<T : SatelliteData>(private val hexagonalGrid: HexagonalGrid<T>) : HexagonalGridCalculator<T> {
+class HexagonalGridCalculatorImpl<T : SatelliteData>(override val hexagonalGrid: HexagonalGrid<T>) : HexagonalGridCalculator<T> {
 
     override fun calculateDistanceBetween(hex0: Hexagon<T>, hex1: Hexagon<T>): Int {
         val absX = abs(hex0.gridX - hex1.gridX)
@@ -42,23 +42,18 @@ class HexagonalGridCalculatorImpl<T : SatelliteData>(private val hexagonalGrid: 
 
     override fun calculateRingFrom(centerHexagon: Hexagon<T>, radius: Int): Set<Hexagon<T>> {
         val result = HashSet<Hexagon<T>>()
-        val startingCoordinate = CubeCoordinate.fromCoordinates(
+
+        var currentCoordinate = CubeCoordinate.fromCoordinates(
                 centerHexagon.gridX - radius,
                 centerHexagon.gridZ + radius
         )
-        val startingHexagon = hexagonalGrid.getByCubeCoordinate(startingCoordinate)
 
-        if (startingHexagon.isPresent) {
-            var currentHexagon = startingHexagon.get()
-            for (i in 0 until 6) {
-                for (j in 0 until radius) {
-                    val neighbor = hexagonalGrid.getNeighborByIndex(currentHexagon, i)
-                    if (neighbor.isPresent) {
-                        currentHexagon = neighbor.get()
-                        result.add(currentHexagon)
-                    } else {
-                        return result
-                    }
+        for (i in 0 until 6) {
+            for (j in 0 until radius) {
+                currentCoordinate = hexagonalGrid.getNeighborCoordinateByIndex(currentCoordinate, i)
+                val hexagon = hexagonalGrid.getByCubeCoordinate(currentCoordinate)
+                if (hexagon.isPresent) {
+                    result.add(hexagon.get())
                 }
             }
         }

--- a/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/internal/impl/HexagonalGridImpl.kt
+++ b/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/internal/impl/HexagonalGridImpl.kt
@@ -135,6 +135,12 @@ class HexagonalGridImpl<T : SatelliteData>(builder: HexagonalGridBuilder<T>) : H
                     hexagon.gridZ + NEIGHBORS[index][NEIGHBOR_Z_INDEX]
             )
 
+    override fun getNeighborCoordinateByIndex(coordinate: CubeCoordinate, index: Int) =
+            CubeCoordinate.fromCoordinates(
+                    coordinate.gridX + NEIGHBORS[index][NEIGHBOR_X_INDEX],
+                    coordinate.gridZ + NEIGHBORS[index][NEIGHBOR_Z_INDEX]
+            )
+
     override fun getNeighborByIndex(hexagon: Hexagon<T>, index: Int) =
             getByCubeCoordinate(_getNeighborByIndex(hexagon, index))
 

--- a/mixite.core/src/commonTest/kotlin/org/hexworks/mixite/core/internal/impl/HexagonalGridCalculatorImplTest.kt
+++ b/mixite.core/src/commonTest/kotlin/org/hexworks/mixite/core/internal/impl/HexagonalGridCalculatorImplTest.kt
@@ -204,4 +204,67 @@ class HexagonalGridCalculatorImplTest {
         assertEquals(expected, actual)
     }
 
+    @Test
+    fun shouldProperlyCalculateRingWhenNearAnEdge() {
+        targetHex = HexagonStub(
+                gridX = 9,
+                gridY = -9,
+                gridZ = 0)
+
+        val expected = HashSet<Hexagon<DefaultSatelliteData>>()
+        expected.add(grid.getByCubeCoordinate(fromCoordinates(8, 0)).get())
+        expected.add(grid.getByCubeCoordinate(fromCoordinates(8, 1)).get())
+        expected.add(grid.getByCubeCoordinate(fromCoordinates(9, 1)).get())
+
+        val actual = target.calculateRingFrom(targetHex, 1)
+        assertEquals(expected, actual)
+
+
+
+        targetHex = HexagonStub(
+                gridX = 0,
+                gridY = 0,
+                gridZ = 0)
+
+        expected.clear()
+        expected.add(grid.getByCubeCoordinate(fromCoordinates(1, 0)).get())
+        expected.add(grid.getByCubeCoordinate(fromCoordinates(0, 1)).get())
+
+        val newActual = target.calculateRingFrom(targetHex, 1)
+        assertEquals(expected, newActual)
+    }
+
+    @Test
+    fun shouldProperlyCalculateRingWhenCenterOffEdge() {
+        targetHex = HexagonStub(
+                gridX = 0,
+                gridY = 1,
+                gridZ = -1
+        )
+
+        val expected = HashSet<Hexagon<DefaultSatelliteData>>()
+        expected.add(grid.getByCubeCoordinate(fromCoordinates(2, 0)).get())
+        expected.add(grid.getByCubeCoordinate(fromCoordinates(1, 1)).get())
+        expected.add(grid.getByCubeCoordinate(fromCoordinates(0, 2)).get())
+        expected.add(grid.getByCubeCoordinate(fromCoordinates(-1, 2)).get())
+
+        val actual =  target.calculateRingFrom(targetHex, 3)
+
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun shouldProperlyCalculateRingAtRadiusOne() {
+        targetHex = HexagonStub(
+                gridX = 4,
+                gridY = 4,
+                gridZ = 4)
+
+        val expected = 6
+
+        val actual = target.calculateRingFrom(targetHex, 1).size
+
+        assertEquals(expected, actual)
+    }
+
 }


### PR DESCRIPTION
Fix #61 
Add new functions to support getting neighbor coordinates even when the hex is not present
Expose hexagonalGrid in HexagonalGridCalculator