### PR TITLE
Enable setting arbitrary GridLayoutStrategies in HexagonalGridBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Hexagonal grids come in **flat topped** and **pointy topped** shapes. The grid c
  - Triangular: the width and height of a this layout has to be equal.
  - Rectangular: no special rules
  - Trapezoid: no special rules
+ - Custom: your own implementation of [`GridLayoutStrategy`][gridlayoutstrategylink]
 
 All layouts have *width* and *height* values of at least **1**.
 You can consult [HexagonalGridLayout][hexgridlayout] if you need further details.
@@ -224,3 +225,4 @@ Pull requests are also welcome!*
 [defsatdatlink]:mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/api/defaults/DefaultSatelliteData.kt
 [hexdatstorlink]:mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/api/contract/HexagonDataStorage.kt
 [defhexdatstorlink]:mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/api/defaults/DefaultHexagonDataStorage.kt
+[gridlayoutstrategylink]:mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/api/GridLayoutStrategy.kt

--- a/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/api/HexagonalGridBuilder.kt
+++ b/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/api/HexagonalGridBuilder.kt
@@ -1,7 +1,6 @@
 package org.hexworks.mixite.core.api
 
 import org.hexworks.mixite.core.api.HexagonOrientation.POINTY_TOP
-import org.hexworks.mixite.core.api.HexagonalGridLayout.RECTANGULAR
 import org.hexworks.mixite.core.api.contract.HexagonDataStorage
 import org.hexworks.mixite.core.api.contract.SatelliteData
 import org.hexworks.mixite.core.api.defaults.DefaultHexagonDataStorage
@@ -9,6 +8,7 @@ import org.hexworks.mixite.core.internal.GridData
 import org.hexworks.mixite.core.internal.impl.HexagonalGridCalculatorImpl
 import org.hexworks.mixite.core.internal.impl.HexagonalGridImpl
 import org.hexworks.mixite.core.internal.impl.layoutstrategy.GridLayoutStrategy
+import org.hexworks.mixite.core.internal.impl.layoutstrategy.RectangularGridLayoutStrategy
 
 /**
  *
@@ -28,10 +28,10 @@ class HexagonalGridBuilder<T : SatelliteData> {
     private var radius: Double = 0.toDouble()
     private val hexagonDataStorage: HexagonDataStorage<T> = DefaultHexagonDataStorage()
     private var orientation = POINTY_TOP
-    private var gridLayout = RECTANGULAR
+    private var gridLayout : GridLayoutStrategy = RectangularGridLayoutStrategy()
 
     val gridLayoutStrategy: GridLayoutStrategy
-        get() = gridLayout.gridLayoutStrategy
+        get() = gridLayout
 
     /**
      * Returns the GridData.
@@ -136,15 +136,27 @@ class HexagonalGridBuilder<T : SatelliteData> {
     }
 
     /**
-     * Sets the [HexagonalGridLayout] which will be used when creating the [HexagonalGrid].
+     * Sets the [GridLayoutStrategy] which will be used when creating the [HexagonalGrid].
      * If it is not set <pre>RECTANGULAR</pre> will be assumed.
      *
      * @param gridLayout layout
      *
      * @return this [HexagonalGridBuilder].
      */
-    fun setGridLayout(gridLayout: HexagonalGridLayout): HexagonalGridBuilder<T> = also {
+    fun setGridLayout(gridLayout: GridLayoutStrategy): HexagonalGridBuilder<T> = also {
         this.gridLayout = gridLayout
+    }
+
+    /**
+     * Sets the [GridLayoutStrategy] which will be used when creating the [HexagonalGrid], based on an existing
+     * [HexagonalGridLayout]. If it is not set <pre>RECTANGULAR</pre> will be assumed.
+     *
+     * @param gridLayout layout
+     *
+     * @return this [HexagonalGridBuilder].
+     */
+    fun setGridLayout(gridLayout: HexagonalGridLayout): HexagonalGridBuilder<T> = also {
+        this.gridLayout = gridLayout.gridLayoutStrategy
     }
 
     private fun checkParameters() {
@@ -152,7 +164,7 @@ class HexagonalGridBuilder<T : SatelliteData> {
             throw IllegalStateException("Radius must be greater than 0.")
         }
         if (!gridLayout.checkParameters(gridHeight, gridWidth)) {
-            throw IllegalStateException("Width: " + gridWidth + " and height: " + gridHeight + " is not valid for: " + gridLayout.name + " layout.")
+            throw IllegalStateException("Width: " + gridWidth + " and height: " + gridHeight + " is not valid for: " + gridLayout.getName() + " layout.")
         }
     }
 }

--- a/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/internal/GridData.kt
+++ b/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/internal/GridData.kt
@@ -2,6 +2,7 @@ package org.hexworks.mixite.core.internal
 
 import org.hexworks.mixite.core.api.HexagonOrientation
 import org.hexworks.mixite.core.api.HexagonalGridLayout
+import org.hexworks.mixite.core.internal.impl.layoutstrategy.GridLayoutStrategy
 import kotlin.math.sqrt
 
 /**
@@ -9,7 +10,7 @@ import kotlin.math.sqrt
  * [org.hexworks.mixite.core.api.HexagonalGrid] and the HexagonalGrid's own immutable properties.
  */
 class GridData(val orientation: HexagonOrientation,
-                    val gridLayout: HexagonalGridLayout,
+                    val gridLayout: GridLayoutStrategy,
                     val radius: Double,
                     val gridWidth: Int,
                     val gridHeight: Int) {

--- a/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/internal/impl/layoutstrategy/GridLayoutStrategy.kt
+++ b/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/internal/impl/layoutstrategy/GridLayoutStrategy.kt
@@ -34,4 +34,11 @@ abstract class GridLayoutStrategy {
         return gridHeight > 0 && gridWidth > 0
     }
 
+    /**
+     * Returns the name of this strategy.
+     *
+     * @return name
+     */
+    abstract fun getName() : String
+
 }

--- a/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/internal/impl/layoutstrategy/HexagonalGridLayoutStrategy.kt
+++ b/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/internal/impl/layoutstrategy/HexagonalGridLayoutStrategy.kt
@@ -36,4 +36,8 @@ class HexagonalGridLayoutStrategy : GridLayoutStrategy() {
         return result && superResult
     }
 
+    override fun getName(): String {
+        return "HEXAGONAL"
+    }
+
 }

--- a/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/internal/impl/layoutstrategy/RectangularGridLayoutStrategy.kt
+++ b/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/internal/impl/layoutstrategy/RectangularGridLayoutStrategy.kt
@@ -22,4 +22,8 @@ class RectangularGridLayoutStrategy : GridLayoutStrategy() {
     override fun checkParameters(gridHeight: Int, gridWidth: Int): Boolean {
         return checkCommonCase(gridHeight, gridWidth)
     }
+
+    override fun getName(): String {
+        return "RECTANGULAR"
+    }
 }

--- a/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/internal/impl/layoutstrategy/TrapezoidGridLayoutStrategy.kt
+++ b/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/internal/impl/layoutstrategy/TrapezoidGridLayoutStrategy.kt
@@ -19,4 +19,8 @@ class TrapezoidGridLayoutStrategy : GridLayoutStrategy() {
     override fun checkParameters(gridHeight: Int, gridWidth: Int): Boolean {
         return checkCommonCase(gridHeight, gridWidth)
     }
+
+    override fun getName(): String {
+        return "TRAPEZOID"
+    }
 }

--- a/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/internal/impl/layoutstrategy/TriangularGridLayoutStrategy.kt
+++ b/mixite.core/src/commonMain/kotlin/org/hexworks/mixite/core/internal/impl/layoutstrategy/TriangularGridLayoutStrategy.kt
@@ -23,4 +23,8 @@ class TriangularGridLayoutStrategy : GridLayoutStrategy() {
         val result = gridHeight == gridWidth
         return superResult && result
     }
+
+    override fun getName(): String {
+        return "TRIANGULAR"
+    }
 }

--- a/mixite.core/src/commonTest/kotlin/org/hexworks/mixite/core/internal/GridDataTest.kt
+++ b/mixite.core/src/commonTest/kotlin/org/hexworks/mixite/core/internal/GridDataTest.kt
@@ -75,6 +75,6 @@ class GridDataTest {
         private const val GRID_WIDTH = 30
         private const val GRID_HEIGHT = 30
         private val ORIENTATION = FLAT_TOP
-        private val GRID_LAYOUT = RECTANGULAR
+        private val GRID_LAYOUT = RECTANGULAR.gridLayoutStrategy
     }
 }

--- a/mixite.core/src/commonTest/kotlin/org/hexworks/mixite/core/internal/impl/CustomGridLayoutHexagonImplTest.kt
+++ b/mixite.core/src/commonTest/kotlin/org/hexworks/mixite/core/internal/impl/CustomGridLayoutHexagonImplTest.kt
@@ -1,0 +1,57 @@
+package org.hexworks.mixite.core.internal.impl
+
+import org.hexworks.mixite.core.api.CoordinateConverter
+import org.hexworks.mixite.core.api.CubeCoordinate
+import org.hexworks.mixite.core.api.Hexagon
+import org.hexworks.mixite.core.api.HexagonalGridBuilder
+import org.hexworks.mixite.core.api.defaults.DefaultSatelliteData
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class CustomGridLayoutHexagonImplTest : HexagonalGridImplTest() {
+
+    override fun getBuilder(): HexagonalGridBuilder<DefaultSatelliteData> {
+        return HexagonalGridBuilder<DefaultSatelliteData>()
+                .setGridLayout(CustomGridLayoutStrategy())
+                .setGridHeight(GRID_HEIGHT)
+                .setGridWidth(GRID_WIDTH)
+                .setRadius(RADIUS.toDouble())
+                .setOrientation(ORIENTATION)
+    }
+
+    override fun shouldReturnProperHexagonsWhenEachHexagonIsTestedInAGivenGrid() {
+        val hexagons = target.hexagons
+        val expectedCoordinates = HashSet<String>()
+        for (x in 0 until GRID_WIDTH) {
+            for (y in 0 until GRID_HEIGHT) {
+                if (y == 0 && x == 0 || y == 0 && x == GRID_WIDTH - 1 || y == GRID_HEIGHT - 1 && x == 0 ||
+                        y == GRID_HEIGHT - 1 && x == GRID_WIDTH - 1) {
+                    continue
+                }
+                val gridX = CoordinateConverter.convertOffsetCoordinatesToCubeX(x, y, ORIENTATION)
+                val gridZ = CoordinateConverter.convertOffsetCoordinatesToCubeZ(x, y, ORIENTATION)
+                expectedCoordinates.add("$gridX,$gridZ")
+            }
+        }
+        var count = 0
+        for (hexagon in hexagons) {
+            expectedCoordinates.remove("${hexagon.gridX},${hexagon.gridZ}")
+            count++
+        }
+        assertEquals(96, count)
+        assertTrue(expectedCoordinates.isEmpty())
+    }
+
+    override fun shouldReturnProperNeighborsOfHexagonWhenHexIsOnTheEdge() {
+        val hex = target.getByCubeCoordinate(CubeCoordinate.fromCoordinates(-4, 8)).get()
+        val expected = HashSet<Hexagon<DefaultSatelliteData>>()
+        expected.add(target.getByCubeCoordinate(CubeCoordinate.fromCoordinates(-3, 7)).get())
+        expected.add(target.getByCubeCoordinate(CubeCoordinate.fromCoordinates(-3, 8)).get())
+        val actual = target.getNeighborsOf(hex)
+        assertEquals(expected, actual)
+    }
+
+    override fun shouldProperlyReturnGridLayoutWhenGetGridLayoutIsCalled() {
+        assertTrue(target.gridData.gridLayout is CustomGridLayoutStrategy)
+    }
+}

--- a/mixite.core/src/commonTest/kotlin/org/hexworks/mixite/core/internal/impl/CustomGridLayoutStrategy.kt
+++ b/mixite.core/src/commonTest/kotlin/org/hexworks/mixite/core/internal/impl/CustomGridLayoutStrategy.kt
@@ -1,0 +1,33 @@
+package org.hexworks.mixite.core.internal.impl
+
+import org.hexworks.mixite.core.api.CoordinateConverter
+import org.hexworks.mixite.core.api.CubeCoordinate
+import org.hexworks.mixite.core.api.HexagonalGridBuilder
+import org.hexworks.mixite.core.api.contract.SatelliteData
+import org.hexworks.mixite.core.internal.impl.layoutstrategy.GridLayoutStrategy
+
+class CustomGridLayoutStrategy : GridLayoutStrategy() {
+
+    override fun fetchGridCoordinates(builder: HexagonalGridBuilder<out SatelliteData>): Iterable<CubeCoordinate> {
+        val coords = ArrayList<CubeCoordinate>( builder.getGridHeight() * builder.getGridWidth())
+        for (y in 0 until builder.getGridHeight()) {
+            val xStart = if (y == 0 || y == builder.getGridHeight() - 1) 1 else 0
+            val xEnd = if (y == 0 || y == builder.getGridHeight() - 1) builder.getGridWidth() - 1
+            else builder.getGridWidth()
+            for (x in xStart until xEnd) {
+                val gridX = CoordinateConverter.convertOffsetCoordinatesToCubeX(x, y, builder.getOrientation())
+                val gridZ = CoordinateConverter.convertOffsetCoordinatesToCubeZ(x, y, builder.getOrientation())
+                coords.add(CubeCoordinate.fromCoordinates(gridX, gridZ))
+            }
+        }
+        return coords
+    }
+
+    override fun checkParameters(gridHeight: Int, gridWidth: Int): Boolean {
+        return true
+    }
+
+    override fun getName(): String {
+        return "CUSTOM"
+    }
+}

--- a/mixite.core/src/commonTest/kotlin/org/hexworks/mixite/core/internal/impl/HexagonImplTest.kt
+++ b/mixite.core/src/commonTest/kotlin/org/hexworks/mixite/core/internal/impl/HexagonImplTest.kt
@@ -113,8 +113,8 @@ class HexagonImplTest {
         private const val EXPECTED_FLAT_CENTER_X = 40
         private const val EXPECTED_POINTY_CENTER_Y = 55
         private const val EXPECTED_FLAT_CENTER_Y = 78
-        private val TEST_POINTY_DATA = GridData(POINTY_TOP, RECTANGULAR, TEST_RADIUS, 1, 1)
-        private val TEST_FLAT_DATA = GridData(FLAT_TOP, RECTANGULAR, TEST_RADIUS, 1, 1)
+        private val TEST_POINTY_DATA = GridData(POINTY_TOP, RECTANGULAR.gridLayoutStrategy, TEST_RADIUS, 1, 1)
+        private val TEST_FLAT_DATA = GridData(FLAT_TOP, RECTANGULAR.gridLayoutStrategy, TEST_RADIUS, 1, 1)
         private val TEST_COORDINATE = fromCoordinates(TEST_GRID_X, TEST_GRID_Z)
         private val TEST_SATELLITE_DATA = DefaultSatelliteData()
         private val TEST_SATELLITE_DATA_MAP = DefaultHexagonDataStorage<DefaultSatelliteData>()

--- a/mixite.core/src/commonTest/kotlin/org/hexworks/mixite/core/internal/impl/HexagonalGridImplTest.kt
+++ b/mixite.core/src/commonTest/kotlin/org/hexworks/mixite/core/internal/impl/HexagonalGridImplTest.kt
@@ -4,20 +4,19 @@ import org.hexworks.mixite.core.api.*
 import org.hexworks.mixite.core.api.CubeCoordinate.Companion.fromCoordinates
 import org.hexworks.mixite.core.api.HexagonalGridLayout.RECTANGULAR
 import org.hexworks.mixite.core.api.defaults.DefaultSatelliteData
+import org.hexworks.mixite.core.internal.impl.layoutstrategy.RectangularGridLayoutStrategy
 import kotlin.test.*
 
-class HexagonalGridImplTest {
+abstract class HexagonalGridImplTest {
 
-    private lateinit var target: HexagonalGrid<DefaultSatelliteData>
+    internal lateinit var target: HexagonalGrid<DefaultSatelliteData>
     private lateinit var builder: HexagonalGridBuilder<DefaultSatelliteData>
+
+    abstract fun getBuilder() : HexagonalGridBuilder<DefaultSatelliteData>
 
     @BeforeTest
     fun setUp() {
-        builder = HexagonalGridBuilder<DefaultSatelliteData>()
-                .setGridHeight(GRID_HEIGHT)
-                .setGridWidth(GRID_WIDTH)
-                .setRadius(RADIUS.toDouble())
-                .setOrientation(ORIENTATION)
+        builder = getBuilder()
         target = builder.build()
     }
 
@@ -37,24 +36,7 @@ class HexagonalGridImplTest {
     }
 
     @Test
-    fun shouldReturnProperHexagonsWhenEachHexagonIsTestedInAGivenGrid() {
-        val hexagons = target.hexagons
-        val expectedCoordinates = HashSet<String>()
-        for (x in 0 until GRID_WIDTH) {
-            for (y in 0 until GRID_HEIGHT) {
-                val gridX = CoordinateConverter.convertOffsetCoordinatesToCubeX(x, y, ORIENTATION)
-                val gridZ = CoordinateConverter.convertOffsetCoordinatesToCubeZ(x, y, ORIENTATION)
-                expectedCoordinates.add("$gridX,$gridZ")
-            }
-        }
-        var count = 0
-        for (hexagon in hexagons) {
-            expectedCoordinates.remove("${hexagon.gridX},${hexagon.gridZ}")
-            count++
-        }
-        assertEquals(100, count)
-        assertTrue(expectedCoordinates.isEmpty())
-    }
+    abstract fun shouldReturnProperHexagonsWhenEachHexagonIsTestedInAGivenGrid()
 
     @Test
     fun shouldReturnProperHexagonsWhenGetHexagonsByAxialRangeIsCalled() {
@@ -182,19 +164,10 @@ class HexagonalGridImplTest {
     }
 
     @Test
-    fun shouldReturnProperNeighborsOfHexagonWhenHexIsOnTheEdge() {
-        val hex = target.getByCubeCoordinate(fromCoordinates(5, 9)).get()
-        val expected = HashSet<Hexagon<DefaultSatelliteData>>()
-        expected.add(target.getByCubeCoordinate(fromCoordinates(5, 8)).get())
-        expected.add(target.getByCubeCoordinate(fromCoordinates(4, 9)).get())
-        val actual = target.getNeighborsOf(hex)
-        assertEquals(expected, actual)
-    }
+    abstract fun shouldReturnProperNeighborsOfHexagonWhenHexIsOnTheEdge()
 
     @Test
-    fun shouldProperlyReturnGridLayoutWhenGetGridLayoutIsCalled() {
-        assertEquals(RECTANGULAR, target.gridData.gridLayout)
-    }
+    abstract fun shouldProperlyReturnGridLayoutWhenGetGridLayoutIsCalled()
 
     @Test
     fun shouldProperlyReturnSharedHexagonDataWhenGetSharedHexagonDataIsCalled() {
@@ -216,13 +189,13 @@ class HexagonalGridImplTest {
 
     companion object {
 
-        private const val RADIUS = 30
-        private const val GRID_WIDTH = 10
-        private const val GRID_HEIGHT = 10
+        internal const val RADIUS = 30
+        internal const val GRID_WIDTH = 10
+        internal const val GRID_HEIGHT = 10
         private const val GRID_X_FROM = 2
         private const val GRID_X_TO = 4
         private const val GRID_Z_FROM = 3
         private const val GRID_Z_TO = 5
-        private val ORIENTATION = HexagonOrientation.POINTY_TOP
+        internal val ORIENTATION = HexagonOrientation.POINTY_TOP
     }
 }

--- a/mixite.core/src/commonTest/kotlin/org/hexworks/mixite/core/internal/impl/RectangularGridLayoutHexagonImplTest.kt
+++ b/mixite.core/src/commonTest/kotlin/org/hexworks/mixite/core/internal/impl/RectangularGridLayoutHexagonImplTest.kt
@@ -1,0 +1,53 @@
+package org.hexworks.mixite.core.internal.impl
+
+import org.hexworks.mixite.core.api.CoordinateConverter
+import org.hexworks.mixite.core.api.CubeCoordinate
+import org.hexworks.mixite.core.api.Hexagon
+import org.hexworks.mixite.core.api.HexagonalGridBuilder
+import org.hexworks.mixite.core.api.defaults.DefaultSatelliteData
+import org.hexworks.mixite.core.internal.impl.layoutstrategy.RectangularGridLayoutStrategy
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class RectangularGridLayoutHexagonImplTest : HexagonalGridImplTest() {
+
+    override fun getBuilder(): HexagonalGridBuilder<DefaultSatelliteData> {
+        return HexagonalGridBuilder<DefaultSatelliteData>()
+                .setGridHeight(GRID_HEIGHT)
+                .setGridWidth(GRID_WIDTH)
+                .setRadius(RADIUS.toDouble())
+                .setOrientation(ORIENTATION)
+    }
+
+    override fun shouldReturnProperHexagonsWhenEachHexagonIsTestedInAGivenGrid() {
+        val hexagons = target.hexagons
+        val expectedCoordinates = HashSet<String>()
+        for (x in 0 until GRID_WIDTH) {
+            for (y in 0 until GRID_HEIGHT) {
+                val gridX = CoordinateConverter.convertOffsetCoordinatesToCubeX(x, y, ORIENTATION)
+                val gridZ = CoordinateConverter.convertOffsetCoordinatesToCubeZ(x, y, ORIENTATION)
+                expectedCoordinates.add("$gridX,$gridZ")
+            }
+        }
+        var count = 0
+        for (hexagon in hexagons) {
+            expectedCoordinates.remove("${hexagon.gridX},${hexagon.gridZ}")
+            count++
+        }
+        assertEquals(100, count)
+        assertTrue(expectedCoordinates.isEmpty())
+    }
+
+    override fun shouldReturnProperNeighborsOfHexagonWhenHexIsOnTheEdge() {
+        val hex = target.getByCubeCoordinate(CubeCoordinate.fromCoordinates(5, 9)).get()
+        val expected = HashSet<Hexagon<DefaultSatelliteData>>()
+        expected.add(target.getByCubeCoordinate(CubeCoordinate.fromCoordinates(5, 8)).get())
+        expected.add(target.getByCubeCoordinate(CubeCoordinate.fromCoordinates(4, 9)).get())
+        val actual = target.getNeighborsOf(hex)
+        assertEquals(expected, actual)
+    }
+
+    override fun shouldProperlyReturnGridLayoutWhenGetGridLayoutIsCalled() {
+        assertTrue(target.gridData.gridLayout is RectangularGridLayoutStrategy)
+    }
+}


### PR DESCRIPTION
The purpose of this change is to enable custom hex boards.  For example, here is one such board I am working with:
![image](https://user-images.githubusercontent.com/1431625/91641699-240a8400-e9db-11ea-9d42-18827dacb830.png)
